### PR TITLE
fix bugs while splitting yolo dataset

### DIFF
--- a/trans_function/COCO_split.py
+++ b/trans_function/COCO_split.py
@@ -43,8 +43,12 @@ def COCO_SPLIT(input_dir,output_dir,train,val,test):
     # 划分数据集
     train_images = images[:num_train]
     val_images = images[num_train:num_train + num_val]
-    test_images = images[num_train + num_val:]
-    
+    if test_ratio != 0.0 or test_ratio != 0:
+        test_images = images[num_train + num_val:]
+    else:
+        test_images = False
+
+
     # 分别为训练集、验证集和测试集创建子文件夹
     train_folder = os.path.join(output_root, "train")
     val_folder = os.path.join(output_root, "val")
@@ -60,8 +64,9 @@ def COCO_SPLIT(input_dir,output_dir,train,val,test):
     for img in val_images:
         shutil.copy(os.path.join(images_folder, img["file_name"]), os.path.join(val_folder, img["file_name"]))
     
-    for img in test_images:
-        shutil.copy(os.path.join(images_folder, img["file_name"]), os.path.join(test_folder, img["file_name"]))
+    if test_images != False:
+        for img in test_images:
+            shutil.copy(os.path.join(images_folder, img["file_name"]), os.path.join(test_folder, img["file_name"]))
     
     # 根据图片id分配annotations
     def filter_annotations(annotations, image_ids):
@@ -69,12 +74,14 @@ def COCO_SPLIT(input_dir,output_dir,train,val,test):
     
     train_ann = filter_annotations(annotations, [img["id"] for img in train_images])
     val_ann = filter_annotations(annotations, [img["id"] for img in val_images])
-    test_ann = filter_annotations(annotations, [img["id"] for img in test_images])
+    if test_images != False:
+        test_ann = filter_annotations(annotations, [img["id"] for img in test_images])
     
     # 生成train.json, val.json, test.json
     train_json = {"images": train_images, "annotations": train_ann, "categories": categories}
     val_json = {"images": val_images, "annotations": val_ann, "categories": categories}
-    test_json = {"images": test_images, "annotations": test_ann, "categories": categories}
+    if test_images != False:
+        test_json = {"images": test_images, "annotations": test_ann, "categories": categories}
     
     with open(os.path.join(output_root, "train.json"), "w") as f:
         json.dump(train_json, f)
@@ -82,8 +89,9 @@ def COCO_SPLIT(input_dir,output_dir,train,val,test):
     with open(os.path.join(output_root, "val.json"), "w") as f:
         json.dump(val_json, f)
     
-    with open(os.path.join(output_root, "test.json"), "w") as f:
-        json.dump(test_json, f)
+    if test_images != False:
+        with open(os.path.join(output_root, "test.json"), "w") as f:
+            json.dump(test_json, f)
     
     print("数据集划分完成！")
 

--- a/trans_function/YOLO_split.py
+++ b/trans_function/YOLO_split.py
@@ -12,8 +12,10 @@ def YOLO_SPLIT(input_dir, output_dir, train, val, test):
     now = datetime.datetime.now()
     folder_name = now.strftime("%Y-%m-%d_%H-%M-%S")
     out_put_name = f'YOLO_{train}_{val}_{test}__{folder_name}'
-    output_dir = os.path.join(output_dir, out_put_name)
-    
+    output_root = os.path.join(output_dir, out_put_name)
+    os.makedirs(output_root, exist_ok=True)
+    output_dir = output_root
+
     shutil.copy(os.path.join(input_dir,'classes.txt'), output_dir)
 
     # 定义训练集、验证集和测试集比例
@@ -57,7 +59,7 @@ def YOLO_SPLIT(input_dir, output_dir, train, val, test):
         if i < train_count:
             output_image_dir = train_image_dir
             output_label_dir = train_label_dir
-        elif i < train_count + valid_count:
+        elif i < train_count + valid_count or test == 0 or test == 0.0:
             output_image_dir = valid_image_dir
             output_label_dir = valid_label_dir
         else:
@@ -81,5 +83,6 @@ if __name__ == '__main__':
     input_folder = './test_data/input/yolo/'
     output_folder = './test_data/output/'
     
-    YOLO_SPLIT(input_folder, output_folder, 0.5, 0.5, 0)
+    # YOLO_SPLIT(input_folder, output_folder, 0.5, 0.5, 0)
+    YOLO_SPLIT(input_folder, output_folder, 0.8, 0.2, 0)
 


### PR DESCRIPTION
1. fix bugs that popout in split yolo dataset function while running ./trans_function/main.py
2. fix bugs that when test_ratio == 0, a single test image is still splitted from the dataset

划分数据集的时候提示数据格式不规范，实际上是yolo_split.py忘记新建文件夹，导致复制图片和标签时找不到路径

Traceback (most recent call last):
  File "d:/Project/Python_lib/AutoDrivingProj/OnlineMatch2025/Object_Detection_Dataset_Conversion--_mac-windows_v1.1/trans_function/YOLO_split.py", line 87, in <module>
    YOLO_SPLIT(input_folder, output_folder, 0.8, 0.2, 0)
  File "d:/Project/Python_lib/AutoDrivingProj/OnlineMatch2025/Object_Detection_Dataset_Conversion--_mac-windows_v1.1/trans_function/YOLO_split.py", line 48, in YOLO_SPLIT
    os.makedirs(train_image_dir, exist_ok=True)
  File "D:\tools\Anaconda3\envs\SmartCar_3_7\lib\os.py", line 213, in makedirs
    makedirs(head, exist_ok=exist_ok)
  File "D:\tools\Anaconda3\envs\SmartCar_3_7\lib\os.py", line 223, in makedirs
    mkdir(name, mode)
FileNotFoundError: [WinError 3] 系统找不到指定的路径。: 'D:\\Project\\Python_lib\\AutoDrivingProj\\OnlineMatch2025\\YOLO\\YOLO_0.8_0.2_0__2025-05-09_14-07-22\\train' 
